### PR TITLE
Small improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,12 @@ script:
   # Make sure Ansible is installed (yes, this is contrived, since Ansible was
   # already installed via pip earlier...).
   - "which ansible"
+
+  # Run the playbook for all users.
+  - 'ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo -e "liquidprompt_apply_all_users=True"'
+
+  # Ensure the liquidprompt bash file was copied system wide.
+  - >
+    [[ -f /etc/profile.d/liquidprompt.sh ]]
+    && (echo 'System wide liquidprompt test: pass' && exit 0)
+    || (echo 'System wide liquidprompt test: fail' && exit 1)

--- a/tasks/all-users-debian.yml
+++ b/tasks/all-users-debian.yml
@@ -3,10 +3,4 @@
 # Option 1: Add liquidprompt to all users
 
 - name: Copy template
-  template: src=liquidprompt.bashrc.j2 dest=/etc/liquidprompt.bashrc owner=root
-
-- name: Add source file to bashrc
-  lineinfile:
-    dest: /etc/bash.bashrc
-    line: "source /etc/liquidprompt.bashrc"
-    owner: root
+  template: src=liquidprompt.bashrc.j2 dest=/etc/profile.d/liquidprompt.sh owner=root

--- a/tasks/install_packages_Debian.yml
+++ b/tasks/install_packages_Debian.yml
@@ -1,0 +1,6 @@
+---
+- name: Install packages for Debian
+  apt: name={{ item }} state=present update_cache=yes cache_valid_time=86400
+  when: ansible_pkg_mgr == 'apt'
+  with_items:
+    - git

--- a/tasks/install_packages_RedHat.yml
+++ b/tasks/install_packages_RedHat.yml
@@ -1,0 +1,6 @@
+---
+- name: Install dependency packages for RedHat
+  yum: name={{ item }} state=present
+  when: ansible_pkg_mgr == 'yum'
+  with_items:
+    - git

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- include: install_packages_Debian.yml
+  sudo: yes
+  tags: package
+  when: ansible_os_family == 'Debian'
+
+- include: install_packages_RedHat.yml
+  sudo: yes
+  tags: package
+  when: ansible_os_family == 'RedHat'
 
 - name: Clone liquidprompt
   git: "repo=https://github.com/nojhan/liquidprompt.git dest={{ liquidprompt_path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,10 @@
 ---
 - include: install_packages_Debian.yml
   sudo: yes
-  tags: package
   when: ansible_os_family == 'Debian'
 
 - include: install_packages_RedHat.yml
   sudo: yes
-  tags: package
   when: ansible_os_family == 'RedHat'
 
 - name: Clone liquidprompt


### PR DESCRIPTION
- Use /etc/profile.d/ for system wide installations

When setting up system wide environmental variables it is recommended to
place your configuration in a shell script within /etc/profile.d.
- Install git

As Git is a requirement to run this role we must ensure that it is present
on the system.
